### PR TITLE
Added link to JCR spec

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -12,6 +12,7 @@ title: Documentation
 - [API Reference](/doc/html/index.html) - Online API documentation for the PHPCR project.
 - [Node Type CND Reference (Jackrabbit)](http://jackrabbit.apache.org/node-type-notation.html) - Detailed definition and
   explanation of the CND node type format.
+- [JCR v2.0 Specification](http://www.day.com/specs/jcr/2.0/index.html) - Online version of the JCR specification.
 - [JCR Query Cheatsheet (Magnolia)](https://wiki.magnolia-cms.com/display/WIKI/JCR+Query+Cheat+Sheet) - Examples of
   the JCR2 query language.
 - [JCR 2.0 SQL-2 Grammer Reference](http://www.h2database.com/jcr/grammar.html#name) - Grammer reference for the JCR-SQL-2 query language.


### PR DESCRIPTION
Just realised that we don't link to the JCR spec on the website.
